### PR TITLE
Declarative defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ SparsePie_tuple(rhubarb=2, cherry=1, mud=None)
 
 Use `enum.default()` to declaratively specify defaults for missing values:
 ```python
->>> class SparsePie(Pie):
+>>> class SparsePie(SparseEnumap):
 ...    rhubarb = default(33)
 ...    cherry = default(22)
 ...    mud = "this is not a default"

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ SparsePie_tuple(rhubarb=None, cherry=None, mud=None)
 SparsePie_tuple(rhubarb=2, cherry=1, mud=None)
 ```
 
-Use `enum.default()` to declaratively specify defaults for missing values:
+Use `enumap.default()` to declaratively specify defaults for missing values:
 ```python
 >>> class SparsePie(SparseEnumap):
 ...    rhubarb = default(33)

--- a/README.md
+++ b/README.md
@@ -96,7 +96,17 @@ SparsePie_tuple(rhubarb=None, cherry=None, mud=None)
 SparsePie_tuple(rhubarb=2, cherry=1, mud=None)
 ```
 
-Use `SparseEnumap.set_defaults` to set more useful default values:
+Use `enum.default()` to declaratively specify defaults for missing values:
+```python
+>>> class SparsePie(Pie):
+...    rhubarb = default(33)
+...    cherry = default(22)
+...    mud = "this is not a default"
+>>> SparsePie.tuple()
+SparsePie_tuple(rhubarb=33, cherry=22, mud=None)
+```
+
+Alternatively, use `SparseEnumap.set_defaults`:
 ```python
 >>> SparsePie.set_defaults(cherry=0, mud=0)
 >>> SparsePie.tuple(30)

--- a/enumap.py
+++ b/enumap.py
@@ -4,7 +4,7 @@ from collections import namedtuple, OrderedDict
 from itertools import zip_longest
 
 
-__version__ = "1.2.3"
+__version__ = "1.3.0"
 
 
 class Enumap(enum.Enum):

--- a/enumap.py
+++ b/enumap.py
@@ -167,7 +167,6 @@ class default(enum.auto):
         >>> Pets.tuple()
         Pets_tuple(dogs=3, cats=44, squirrels=None)
     """
-    _value = (enum.auto.value, None)
 
     def __init__(self, default_value=None):
         self._value = (enum.auto.value, default_value)
@@ -175,7 +174,6 @@ class default(enum.auto):
     @property
     def value(self):
         return self
-        return self._value
 
     @value.setter
     def value(self, new_value):

--- a/test.py
+++ b/test.py
@@ -2,7 +2,7 @@
 
 import pytest
 from collections import OrderedDict
-from enumap import Enumap as EM, SparseEnumap as SEM
+from enumap import Enumap as EM, SparseEnumap as SEM, default
 from decimal import Decimal
 
 
@@ -116,6 +116,27 @@ def test_sparse_tuple():
     a.set_defaults(c="WONK", d=0)
     assert (a.tuple(*"1 3".split(), c="2.2") ==
             ("1", "2.2", 0, None))
+
+
+def test_declarative_defaults():
+    """ Check that enumap.default(value) works as a declarative alternative
+    to SparseEnuamp.set_defaults(...)
+    """
+    class A(SEM):
+        a: int = default(5)
+        b: int = default(44)
+        c: float = default(5.2)
+
+    assert A.tuple() == (5, 44, 5.2)
+
+
+def test_declarative_casted_defaults():
+    class A(SEM):
+        a: int = default(5)
+        b: int = default(44)
+        c: float = default(5.2)
+
+    assert A.tuple_casted(c="9.9") == (5, 44, 9.9)
 
 
 def test_sparse_map():


### PR DESCRIPTION
For @jonemo's issue #1.

# Usage
```
from enumap import default, SparseEnumap

>>> class SparsePie(SparseEnumap):
...    rhubarb = default(33)
...    cherry = default(22)
...    mud = "this is not a default"
>>> SparsePie.tuple()
SparsePie_tuple(rhubarb=33, cherry=22, mud=None)
```

# Why does it work this way?
`enum.Enum` members have to be unique. This is what `enum.auto()` is for. `enumap.default` gives the user a way of indicating that a field should have a default value while also giving the underlying `Enum` a unique member value.