### PR TITLE
Type cast exceptions

### DIFF
--- a/enumap.py
+++ b/enumap.py
@@ -217,7 +217,7 @@ class SparseEnumap(Enumap):
         except AttributeError:
             members = cls.__members__
             defaults_spec = Enumap("_Defaults", cls.names())
-            declarative_defaults = dict(_iter_member_defeaults(members))
+            declarative_defaults = dict(_iter_member_defaults(members))
             member_defaults = defaults_spec.map(
                 *[None] * len(cls), **declarative_defaults)
             cls.__member_defaults = member_defaults

--- a/enumap.py
+++ b/enumap.py
@@ -216,7 +216,10 @@ class SparseEnumap(Enumap):
             return cls.__member_defaults
         except AttributeError:
             members = cls.__members__
-            member_defaults = dict(_iter_member_defaults(members))
+            defaults_spec = Enumap("_Defaults", cls.names())
+            declarative_defaults = dict(_iter_member_defeaults(members))
+            member_defaults = defaults_spec.map(
+                *[None] * len(cls), **declarative_defaults)
             cls.__member_defaults = member_defaults
             return cls.__member_defaults
 

--- a/enumap.py
+++ b/enumap.py
@@ -217,7 +217,7 @@ class SparseEnumap(Enumap):
         except AttributeError:
             members = cls.__members__
             defaults_spec = Enumap("_Defaults", cls.names())
-            declarative_defaults = dict(_iter_member_defaults(members))
+            declared_defaults = dict(_iter_member_defaults(members))
             member_defaults = defaults_spec.map(
                 *[None] * len(cls), **declarative_defaults)
             cls.__member_defaults = member_defaults

--- a/enumap.py
+++ b/enumap.py
@@ -152,11 +152,12 @@ def _type_cast_items(mapping, types):
     """Generates key/value pairs for which each
     value is casted with the callable in the `types` mapping.
     """
-    key = value = None
+    key = None
     try:
         for key, type_callable in types.items():
             yield key, type_callable(mapping[key])
     except Exception as e:
+        value = mapping.get(key)
         value_type = type(value)
         raise TypeCastError(f"Key '{key}' got invalid value '{value}' "
                             f"of type {value_type} (error: '{e}')", key)

--- a/enumap.py
+++ b/enumap.py
@@ -247,7 +247,7 @@ class SparseEnumap(Enumap):
             defaults_spec = Enumap("_Defaults", cls.names())
             declared_defaults = dict(_iter_member_defaults(members))
             member_defaults = defaults_spec.map(
-                *[None] * len(cls), **declarative_defaults)
+                *[None] * len(cls), **declared_defaults)
             cls.__member_defaults = member_defaults
             return cls.__member_defaults
 
@@ -305,8 +305,8 @@ class SparseEnumap(Enumap):
         types = cls.types()
         if types:
             present_typed = present & set(types)
-            mapping.update(((k, types[k](mapping[k]))
-                            for k in present_typed))
+            relevant_types = {key: types[key] for key in present_typed}
+            mapping.update(_type_cast_items(mapping, relevant_types))
 
         # Handle default values to create a sparse mapping.
         # Missing values will either be filled in with what's in the

--- a/enumap.py
+++ b/enumap.py
@@ -158,7 +158,7 @@ def _type_cast_items(mapping, types):
             yield key, type_callable(mapping[key])
     except Exception as e:
         value = mapping.get(key)
-        value_type = type(value)
+        value_type = type(value).__name__
         raise TypeCastError(f"Key '{key}' got invalid value '{value}' "
                             f"of type {value_type} (error: '{e}')", key)
 

--- a/test.py
+++ b/test.py
@@ -130,6 +130,15 @@ def test_declarative_defaults():
     assert A.tuple() == (5, 44, 5.2)
 
 
+def test_declarative_defaults_sparse():
+    class A(SEM):
+        a: int = 5
+        b: int = default(44)
+        c: float = default(5.2)
+
+    assert A.tuple() == (None, 44, 5.2)
+
+
 def test_declarative_casted_defaults():
     class A(SEM):
         a: int = default(5)

--- a/test.py
+++ b/test.py
@@ -179,7 +179,7 @@ def test_type_cast_exception():
     with pytest.raises(TypeCastError) as e:
         A.tuple_casted("1", None)
     assert "'this_here_is_a_bad_key' got invalid value 'None'" in str(e)
-    assert "of type <class 'NoneType'>" in str(e)
+    assert "of type NoneType" in str(e)
     assert e.value.key == "this_here_is_a_bad_key"
 
 
@@ -193,7 +193,7 @@ def test_type_cast_exception_non_nonetype():
         A.tuple_casted("1.0", None)
 
     assert "'a' got invalid value '1.0'" in str(e)
-    assert "of type <class 'str'>" in str(e)
+    assert "of type str" in str(e)
     assert e.value.key == "a"
 
 

--- a/test.py
+++ b/test.py
@@ -148,6 +148,21 @@ def test_declarative_casted_defaults():
     assert A.tuple_casted(c="9.9") == (5, 44, 9.9)
 
 
+def test_declarative_defaults_dictionary():
+    class A(SEM):
+        a: int = default(5)
+        b: int = 2
+        c: float = default(5.2)
+
+    class B(SEM):
+        a: int = 1
+        b: int = 2
+        c: float = 3
+
+    B.set_defaults(a=5, c=5.2)
+    assert B.defaults() == A.defaults()
+
+
 def test_sparse_map():
     a = SEM("a", names="b c e")
     assert (a.map(*"1 3".split(), c="2.2") ==

--- a/test.py
+++ b/test.py
@@ -9,8 +9,8 @@ from enumap import Enumap, SparseEnumap, default, TypeCastError
 
 def test_map():
     a = Enumap("a", names="b c e")
-    assert a.map(1, 2, 3, e=33) == \
-           OrderedDict([('b', 1), ('c', 2), ('e', 33)])
+    assert (a.map(1, 2, 3, e=33) ==
+            OrderedDict([('b', 1), ('c', 2), ('e', 33)]))
 
 
 def test_tuple():
@@ -29,7 +29,8 @@ def test_ordering():
     assert list(b.tuple(*range(100), n42=9000)) == expected_b
 
 
-to_int = lambda num: int(float(num))
+def to_int(num):
+    return int(float(num))
 
 
 def test_map_casted_0():
@@ -62,8 +63,8 @@ def test_annotated_tuple_casted():
         cost: Decimal = "Total pretax cost"
         due_on: str = "Delivery date"
 
-    assert Order.tuple_casted(*"12 142.22 2017-04-02".split()) == \
-           (12, Decimal("142.22"), "2017-04-02")
+    assert (Order.tuple_casted(*"12 142.22 2017-04-02".split()) ==
+            (12, Decimal("142.22"), "2017-04-02"))
 
 
 def test_annotated_map_casted():
@@ -72,8 +73,8 @@ def test_annotated_map_casted():
         cost: Decimal = "Total pretax cost"
         due_on: str = "Delivery date"
 
-    assert Order.map_casted(*"12 142.22 2017-04-07".split()) == \
-           dict(index=12, cost=Decimal("142.22"), due_on="2017-04-07")
+    assert (Order.map_casted(*"12 142.22 2017-04-07".split()) ==
+            dict(index=12, cost=Decimal("142.22"), due_on="2017-04-07"))
 
 
 def test_names():
@@ -179,6 +180,7 @@ def test_type_cast_exception():
         A.tuple_casted("1", None)
     assert "'this_here_is_a_bad_key' got invalid value 'None'" in str(e)
     assert "of type <class 'NoneType'>" in str(e)
+    assert e.value.key == "this_here_is_a_bad_key"
 
 
 def test_sparse_types():
@@ -210,8 +212,8 @@ def test_sparse_annotations():
         d = 4
 
     assert dict(A.types()) == dict(a=float, b=float)
-    assert dict(A.map_casted(*("1.2 1 hello world".split()))) == \
-           dict(a=1.2, b=1.0, c="hello", d="world")
+    assert (dict(A.map_casted(*("1.2 1 hello world".split()))) ==
+            dict(a=1.2, b=1.0, c="hello", d="world"))
 
 
 def test_too_many_args():

--- a/test.py
+++ b/test.py
@@ -187,10 +187,27 @@ def test_type_cast_exception_non_nonetype():
     """Make sure our type casting exceptions are informative"""
     class A(Enumap):
         a: int = auto()
-        this_here_is_a_bad_key = auto()
+        this_here_is_a_fine_key = auto()
 
     with pytest.raises(TypeCastError) as e:
         A.tuple_casted("1.0", None)
+
+    assert "'a' got invalid value '1.0'" in str(e)
+    assert "of type str" in str(e)
+    assert e.value.key == "a"
+
+
+def test_type_cast_exception_sparse():
+    class A(SparseEnumap):
+        a: int = default(1)
+        b: float = default(2.0)
+        a_fine_key = auto()
+        c = default("a pastry")
+
+    assert A.tuple_casted() == (1, 2.0, None, "a pastry")
+
+    with pytest.raises(TypeCastError) as e:
+        A.tuple_casted("1.0")
 
     assert "'a' got invalid value '1.0'" in str(e)
     assert "of type str" in str(e)

--- a/test.py
+++ b/test.py
@@ -133,7 +133,7 @@ def test_declarative_defaults():
 
 
 def test_declarative_defaults_sparse():
-    class A(SEM):
+    class A(SparseEnumap):
         a: int = 5
         b: int = default(44)
         c: float = default(5.2)
@@ -151,12 +151,12 @@ def test_declarative_casted_defaults():
 
 
 def test_declarative_defaults_dictionary():
-    class A(SEM):
+    class A(SparseEnumap):
         a: int = default(5)
         b: int = 2
         c: float = default(5.2)
 
-    class B(SEM):
+    class B(SparseEnumap):
         a: int = 1
         b: int = 2
         c: float = 3

--- a/test.py
+++ b/test.py
@@ -2,24 +2,25 @@
 
 import pytest
 from collections import OrderedDict
-from enumap import Enumap as EM, SparseEnumap as SEM, default
 from decimal import Decimal
+from enum import auto
+from enumap import Enumap, SparseEnumap, default, TypeCastError
 
 
 def test_map():
-    a = EM("a", names="b c e")
+    a = Enumap("a", names="b c e")
     assert a.map(1, 2, 3, e=33) == \
            OrderedDict([('b', 1), ('c', 2), ('e', 33)])
 
 
 def test_tuple():
-    a = EM("a", names="b c e")
+    a = Enumap("a", names="b c e")
     assert a.tuple(1, 2, 3, e=33) == (1, 2, 33)
 
 
 def test_ordering():
-    a = EM("forward", names=["n" + str(i) for i in range(100)])
-    b = EM("backward", names=["n" + str(i) for i in range(99, -1, -1)])
+    a = Enumap("forward", names=["n" + str(i) for i in range(100)])
+    b = Enumap("backward", names=["n" + str(i) for i in range(99, -1, -1)])
     expected_a = list(range(100))
     expected_a[42] = 9000
     assert list(a.tuple(*range(100), n42=9000)) == expected_a
@@ -32,31 +33,31 @@ to_int = lambda num: int(float(num))
 
 
 def test_map_casted_0():
-    a = EM("a", names="b c e")
+    a = Enumap("a", names="b c e")
     a.set_types(to_int, to_int, float)
     assert a.map_casted(*"1 2.2 3.3".split()) == dict(b=1, c=2, e=3.3)
 
 
 def test_map_casted_1():
-    a = EM("a", names="b c e")
+    a = Enumap("a", names="b c e")
     a.set_types(to_int, to_int, float, e=to_int)
     assert a.map_casted(*"1 2.2 3.3".split()) == dict(b=1, c=2, e=3)
 
 
 def test_tuple_casted_0():
-    a = EM("a", names="b c e")
+    a = Enumap("a", names="b c e")
     a.set_types(to_int, to_int, float)
     assert a.tuple_casted(*"1 2.2 3.3".split()) == (1, 2, 3.3)
 
 
 def test_tuple_casted_1():
-    a = EM("a", names="b c e")
+    a = Enumap("a", names="b c e")
     a.set_types(to_int, to_int, float, e=to_int)
     assert a.tuple_casted(*"1 2.2 3.3".split(), b=2.2) == (2, 2, 3.0)
 
 
 def test_annotated_tuple_casted():
-    class Order(str, EM):
+    class Order(str, Enumap):
         index: int = "Order ID"
         cost: Decimal = "Total pretax cost"
         due_on: str = "Delivery date"
@@ -66,7 +67,7 @@ def test_annotated_tuple_casted():
 
 
 def test_annotated_map_casted():
-    class Order(str, EM):
+    class Order(str, Enumap):
         index: int = "Order ID"
         cost: Decimal = "Total pretax cost"
         due_on: str = "Delivery date"
@@ -76,43 +77,43 @@ def test_annotated_map_casted():
 
 
 def test_names():
-    assert list(EM("a", names="b c e").names()) == ["b", "c", "e"]
+    assert list(Enumap("a", names="b c e").names()) == ["b", "c", "e"]
 
 
 def test_tuple_class():
-    a = EM("a", names="b c e")
+    a = Enumap("a", names="b c e")
     assert a.tuple_class()._fields == ("b", "c", "e")
 
 
 def test_member_types():
-    Pastry = EM("Pastry", names="croissant donut muffin")
+    Pastry = Enumap("Pastry", names="croissant donut muffin")
     Pastry.set_types(int, int, int, donut=float)  # override donut with kwarg
     assert (Pastry.types() ==
             {'croissant': int, 'donut': float, 'muffin': int})
 
 
 def test_missing_key():
-    a = EM("a", names="b c e")
+    a = Enumap("a", names="b c e")
     with pytest.raises(KeyError) as ke:
         assert a.tuple(*"1 3".split())
     assert "missing keys {'e'}" in str(ke)
 
 
 def test_bad_key():
-    a = EM("a", names="b c e")
+    a = Enumap("a", names="b c e")
     with pytest.raises(KeyError) as ke:
         assert a.tuple(*"1 3 4".split(), f="nope")
     assert "invalid keys {'f'}" in str(ke)
 
 
 def test_sparse_defaults():
-    a = SEM("a", names="b c d e")
+    a = SparseEnumap("a", names="b c d e")
     a.set_defaults(c="WONK", d=0)
     assert a.tuple(**a.defaults()) == (None, "WONK", 0, None)
 
 
 def test_sparse_tuple():
-    a = SEM("a", names="b c d e")
+    a = SparseEnumap("a", names="b c d e")
     a.set_defaults(c="WONK", d=0)
     assert (a.tuple(*"1 3".split(), c="2.2") ==
             ("1", "2.2", 0, None))
@@ -122,7 +123,7 @@ def test_declarative_defaults():
     """ Check that enumap.default(value) works as a declarative alternative
     to SparseEnuamp.set_defaults(...)
     """
-    class A(SEM):
+    class A(SparseEnumap):
         a: int = default(5)
         b: int = default(44)
         c: float = default(5.2)
@@ -131,7 +132,7 @@ def test_declarative_defaults():
 
 
 def test_declarative_casted_defaults():
-    class A(SEM):
+    class A(SparseEnumap):
         a: int = default(5)
         b: int = default(44)
         c: float = default(5.2)
@@ -140,20 +141,20 @@ def test_declarative_casted_defaults():
 
 
 def test_sparse_map():
-    a = SEM("a", names="b c e")
+    a = SparseEnumap("a", names="b c e")
     assert (a.map(*"1 3".split(), c="2.2") ==
             OrderedDict([("b", "1"), ("c", "2.2"), ("e", None)]))
 
 
 def test_sparse_casted_tuple():
-    a = SEM("a", names="a b c e")
+    a = SparseEnumap("a", names="a b c e")
     a.set_types(to_int, to_int, float, float)
     casted_tuple = a.tuple_casted(*"1.1 2.2 3.3".split())
     assert casted_tuple == (1, 2, 3.3, None)  # missing values aren't casted
 
 
 def test_sparse_casted_tuple_with_default():
-    a = SEM("a", names="a b c e")
+    a = SparseEnumap("a", names="a b c e")
     a.set_types(to_int, to_int, float, int)
     a.set_defaults(e="HOOP")
     casted_tuple = a.tuple_casted(*"1.1 2.2".split())
@@ -161,35 +162,48 @@ def test_sparse_casted_tuple_with_default():
 
 
 def test_sparse_casted_map():
-    a = SEM("a", names="a b c e")
+    a = SparseEnumap("a", names="a b c e")
     a.set_types(to_int, to_int, float, float)
     casted_map = a.map_casted(*"1.1 2.2 3.3".split())
     assert tuple(casted_map.values()) == (1, 2, 3.3, None)
 
 
+def test_type_cast_exception():
+    """Make sure our type casting exceptions are informative"""
+    class A(Enumap):
+        a: int = auto()
+        this_here_is_a_bad_key: int = auto()
+
+    assert A.tuple_casted("1", "2") == (1, 2)
+    with pytest.raises(TypeCastError) as e:
+        A.tuple_casted("1", None)
+    assert "'this_here_is_a_bad_key' got invalid value 'None'" in str(e)
+    assert "of type <class 'NoneType'>" in str(e)
+
+
 def test_sparse_types():
     """Check that SparseEnumap's types can be sparse.
     Missing type callables won't be called on values."""
-    a = SEM("a", names="a b c e")
+    a = SparseEnumap("a", names="a b c e")
     a.set_types(int, int, int)  # sparse types; only two of four set
     a.set_defaults(b=3000, c="heyo")
     assert a.tuple_casted("1", "1") == (1, 1, "heyo", None)
-    a = EM("a", "a b c")
+    a = Enumap("a", "a b c")
     a.set_types(a=int, b=int)
     assert a.types() == dict(a=int, b=int)
 
 
 def test_typless():
     """Make sure types are allowed to be blank"""
-    a = EM("A", "a b c".split())
-    b = SEM("B", "a b c".split())
+    a = Enumap("A", "a b c".split())
+    b = SparseEnumap("B", "a b c".split())
     assert a.types() == {}
     assert b.types() == {}
 
 
 def test_sparse_annotations():
     """Check that SparseEnumap allows for sparse type annotations"""
-    class A(SEM):
+    class A(SparseEnumap):
         a: float = 1
         b: float = 2
         c = 3
@@ -202,7 +216,7 @@ def test_sparse_annotations():
 
 def test_too_many_args():
     """Ensure that Enumaps will not accept too many arguments"""
-    class A(EM):
+    class A(Enumap):
         a = 1
         b = 2
         c = 3
@@ -219,7 +233,7 @@ def test_too_many_args():
 def test_too_many_args_casted():
     """Ensure that Enumaps will not accept too many arguments for
     *_casted methods"""
-    class A(EM):
+    class A(Enumap):
         a: int = 1
         b: int = 2
         c: int = 3
@@ -235,7 +249,7 @@ def test_too_many_args_casted():
 
 def test_too_many_args_sparse():
     """Ensure that SparseEnumaps will not accept too many arguments"""
-    class A(SEM):
+    class A(SparseEnumap):
         a: int = 1
         b = 2
         c: int = 3
@@ -252,7 +266,7 @@ def test_too_many_args_sparse():
 def test_too_many_args_sparse_casted():
     """Ensure that SparseEnumaps will not accept too many arguments for
     *_casted methods"""
-    class A(SEM):
+    class A(SparseEnumap):
         a: int = 1
         b = 2
         c: int = 3
@@ -267,7 +281,7 @@ def test_too_many_args_sparse_casted():
 
 
 def test_sparse_bad_key():
-    a = SEM("a", names="b c e")
+    a = SparseEnumap("a", names="b c e")
     with pytest.raises(KeyError) as ke:
         assert a.tuple(*"1 3".split(), f="nope")
     assert "invalid keys {'f'}" in str(ke)
@@ -275,6 +289,6 @@ def test_sparse_bad_key():
 
 def test_copy_from_names():
     """Check that Enumap.names() can be used to construct another Enumap"""
-    a = EM("a", "b c d")
-    b = EM("b", a.names())
+    a = Enumap("a", "b c d")
+    b = Enumap("b", a.names())
     assert a.map(*range(3)) == b.map(*range(3))

--- a/test.py
+++ b/test.py
@@ -183,6 +183,20 @@ def test_type_cast_exception():
     assert e.value.key == "this_here_is_a_bad_key"
 
 
+def test_type_cast_exception_non_nonetype():
+    """Make sure our type casting exceptions are informative"""
+    class A(Enumap):
+        a: int = auto()
+        this_here_is_a_bad_key = auto()
+
+    with pytest.raises(TypeCastError) as e:
+        A.tuple_casted("1.0", None)
+
+    assert "'a' got invalid value '1.0'" in str(e)
+    assert "of type <class 'str'>" in str(e)
+    assert e.value.key == "a"
+
+
 def test_sparse_types():
     """Check that SparseEnumap's types can be sparse.
     Missing type callables won't be called on values."""


### PR DESCRIPTION
# Better exceptions for type casting
Exceptions for uncastable values during calls to `Enumap.map_casted` and `Enumap.tuple_casted` should be
1. **catchable**: as TypeErrors or a subclass of TypeError
2. **descriptive**: it should be clear which key/field name got a bad, uncastable value
3. **not slower**: than the previous implementation

## 1. Catchable
A new `enumap.TypeCastError` gives the user a specific exception to try/except. For example:

```python
class Creature(Enumap):
    bear: int = 1
    snake: float = 2
    ants: list = 3
```

Given good values:
```python
>>> Animal.tuple_casted("1", "2.3", "abc")
Animal_tuple(bear=1, snake=2.3, ants=['a', 'b', 'c'])
```

Given a bad, uncastable value:
```python
>>> Creature.tuple_casted("1.0", "2.3", "abc")
...
enumap.TypeCastError: Key 'bear' got invalid value '1.0' of type <class 'str'> (error: 'invalid literal for int() with base 10: '1.0'')
```

... which can be caught like:
```python
try:
    Creature.tuple_casted("1.0", "2.3", "abc")
except TypeError:
     ...
```

or with the `enumap` exception itself like:

```python
from enumap import TypeCastError
try:
    Creature.tuple_casted("1.0", "2.3", "abc")
except TypeCastError:
     ...
```

## 2. Descriptive
The exceptions have to tell the programmer which field was wrong and why. `TypeCastError.key` stores the key/field name for which a value couldn't be type casted.

## 3. Not slower
For the case where lots of collections are created from raw data, this code ought not be slow. Benchmark comparisons to 1.3.0:

On this branch:
```
(env) tad@tad-x1:~/tempo/mappable-enum$ pytest benchmark.py -s -v -k casted
...
benchmark.py::test_smallish_casted_tuple 
...
Enumap.tuple_casted                      0.72
Enumap.tuple_casted (with kwargs)        0.86
Enumap.tuple_casted (with override)      0.73
Enumap.tuple_casted (sparse)             0.84
Enumap.tuple_casted (sparse, typeless)   0.63
tuple(map(int, ...))                     0.18
namedtuple(map(int, ...))                0.22
```

On 1.3.0:
```
(env) tad@tad-x1:~/tempo/mappable-enum$ git checkout 1.3.0
...
(env) tad@tad-x1:~/tempo/mappable-enum$ pytest benchmark.py -s -v -k casted
...
benchmark.py::test_smallish_casted_tuple 
Enumap.tuple_casted                      0.76
Enumap.tuple_casted (with kwargs)        0.93
Enumap.tuple_casted (with override)      0.81
Enumap.tuple_casted (sparse)             0.85
Enumap.tuple_casted (sparse, typeless)   0.62
tuple(map(int, ...))                     0.18
namedtuple(map(int, ...))                0.22
```