### PR TITLE
Issue 4: sparse declarative defaults

### DIFF
--- a/enumap.py
+++ b/enumap.py
@@ -217,7 +217,7 @@ class SparseEnumap(Enumap):
         except AttributeError:
             members = cls.__members__
             defaults_spec = Enumap("_Defaults", cls.names())
-            declarative_defaults = dict(_iter_member_defeaults(members))
+            declarative_defaults = dict(_iter_member_defaults(members))
             member_defaults = defaults_spec.map(
                 *[None] * len(cls), **declarative_defaults)
             cls.__member_defaults = member_defaults

--- a/enumap.py
+++ b/enumap.py
@@ -216,7 +216,10 @@ class SparseEnumap(Enumap):
             return cls.__member_defaults
         except AttributeError:
             members = cls.__members__
-            member_defaults = dict(_iter_member_defaults(members))
+            defaults_spec = Enumap("_Defaults", cls.names())
+            declarative_defaults = dict(_iter_member_defeaults(members))
+            member_defaults = defaults_spec.map(
+                *[None] * len(cls), **declarative_defaults)
             cls.__member_defaults = member_defaults
             return cls.__member_defaults
 

--- a/enumap.py
+++ b/enumap.py
@@ -217,7 +217,7 @@ class SparseEnumap(Enumap):
         except AttributeError:
             members = cls.__members__
             defaults_spec = Enumap("_Defaults", cls.names())
-            declarative_defaults = dict(_iter_member_defaults(members))
+            declared_defaults = dict(_iter_member_defaults(members))
             member_defaults = defaults_spec.map(
                 *[None] * len(cls), **declarative_defaults)
             cls.__member_defaults = member_defaults

--- a/test.py
+++ b/test.py
@@ -130,6 +130,15 @@ def test_declarative_defaults():
     assert A.tuple() == (5, 44, 5.2)
 
 
+def test_declarative_defaults_sparse():
+    class A(SEM):
+        a: int = 5
+        b: int = default(44)
+        c: float = default(5.2)
+
+    assert A.tuple() == (None, 44, 5.2)
+
+
 def test_declarative_casted_defaults():
     class A(SEM):
         a: int = default(5)

--- a/test.py
+++ b/test.py
@@ -148,6 +148,21 @@ def test_declarative_casted_defaults():
     assert A.tuple_casted(c="9.9") == (5, 44, 9.9)
 
 
+def test_declarative_defaults_dictionary():
+    class A(SEM):
+        a: int = default(5)
+        b: int = 2
+        c: float = default(5.2)
+
+    class B(SEM):
+        a: int = 1
+        b: int = 2
+        c: float = 3
+
+    B.set_defaults(a=5, c=5.2)
+    assert B.defaults() == A.defaults()
+
+
 def test_sparse_map():
     a = SEM("a", names="b c e")
     assert (a.map(*"1 3".split(), c="2.2") ==


### PR DESCRIPTION
# Declarative defaults now handle sparseness
A fix for #4. The old way of setting `SparseEnumap` defaults (`SparseEnumap.set_defaults(...)`) handled sparseness correctly. That is, calling `set_defaults(*args, **kwargs)` created a defaults dictionary with `None` placeholders. For example:

```python
class People(SparseEnumap):
    donald = auto()
    vladimir = auto()
    william = auto

People.set_defaults(donald=1, william=5)
People.defaults()   # {"donald": 1, "vladimir": None, "william": 5}
```

The declarative version:
```python
class People(SparseEnumap):
    donald = auto()
    vladimir = auto()
    william = auto

People.defaults()   # {"donald": 1, "william": 5}
```
... was broken. Each member in a `SparseEnumap` should have a default no matter what.