### PR TITLE
Bump 1.4.0

### DIFF
--- a/enumap.py
+++ b/enumap.py
@@ -4,7 +4,7 @@ from collections import namedtuple, OrderedDict
 from itertools import zip_longest
 
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 
 
 class Enumap(enum.Enum):


### PR DESCRIPTION
Just bumps `__version__` for the PyPi release.