### PR TITLE
Better REPL behavior

### DIFF
--- a/enumap.py
+++ b/enumap.py
@@ -251,7 +251,23 @@ def _iter_member_defaults(members):
         # aren't are basically just aliases
 
 
-class SparseEnumap(Enumap):
+class SparseEnumapMeta(EnumapMeta):
+    """An EnumMeta for friendlier, more informative REPL behavior"""
+
+    def _iter_fmt_parts(cls):
+        # None defaults are not explicitly shown for readability
+        names = cls.names()
+        types = cls.types()
+        defaults = cls.defaults()
+        for name in names:
+            type_ = types.get(name)
+            default = defaults.get(name)
+            type_info = f": {type_.__name__}" if type_ is not None else ""
+            default_info = f" = {default!r}" if default is not None else ""
+            yield f"{name}{type_info}{default_info}"
+
+
+class SparseEnumap(Enumap, metaclass=SparseEnumapMeta):
     """A less strict Enumap that provides default values
     for unspecified keys. Invalid keys are still prohibited."""
 

--- a/enumap.py
+++ b/enumap.py
@@ -7,7 +7,28 @@ from itertools import zip_longest
 __version__ = "1.3.0"
 
 
-class Enumap(enum.Enum):
+class EnumapMeta(enum.EnumMeta):
+    """An EnumMeta for friendlier, more informative REPL behavior"""
+
+    def _iter_fmt_parts(cls):
+        names = cls.names()
+        types = cls.types()
+        for name in names:
+            type_ = types.get(name)
+            type_info = f": {type_.__name__}" if type_ is not None else ""
+            yield f"{name}{type_info}"
+
+    def __repr__(cls):
+        lines = cls._iter_fmt_parts()
+        indented_lines = ("    " + l for l in lines)
+        return f"{cls.__name__}(\n" + ",\n".join(indented_lines) + "\n)"
+
+    def __str__(cls):
+        parts = cls._iter_fmt_parts()
+        return f"{cls.__name__}(" + ", ".join(parts) + ")"
+
+
+class Enumap(enum.Enum, metaclass=EnumapMeta):
     """An Enum that maps data to its ordered, named members.
     Produces OrderedDicts and namedtuples while ensuring that the
     keys/fields match the names of the Enum members."""

--- a/enumap.py
+++ b/enumap.py
@@ -4,7 +4,7 @@ from collections import namedtuple, OrderedDict
 from itertools import zip_longest
 
 
-__version__ = "1.3.0"
+__version__ = "1.5.0"
 
 
 class EnumapMeta(enum.EnumMeta):

--- a/test.py
+++ b/test.py
@@ -349,3 +349,46 @@ def test_copy_from_names():
     a = Enumap("a", "b c d")
     b = Enumap("b", a.names())
     assert a.map(*range(3)) == b.map(*range(3))
+
+
+def test_repr():
+    """Make sure that EnumapMeta's __repr___ method works"""
+    a = Enumap("a", "b c d")
+    assert repr(a) == """a(
+    b,
+    c,
+    d
+)"""
+
+
+def test_repr_typed():
+    """Make sure that EnumapMeta's __repr___ method works with typed fields"""
+    class Tools(Enumap):
+        head = auto()
+        horse: float = auto()
+        donkey: int = auto()
+        spatula = auto()
+
+    assert repr(Tools) == """Tools(
+    head,
+    horse: float,
+    donkey: int,
+    spatula
+)"""
+
+
+def test_str():
+    """Check that EnumapMeta's __str__ method works"""
+    a = Enumap("a", "b c d")
+    assert str(a) == "a(b, c, d)"
+
+
+def test_str_typed():
+    """Make sure that EnumapMeta's __str___ method works with typed fields"""
+    class Tools(Enumap):
+        head = auto()
+        horse: float = auto()
+        donkey: int = auto()
+        spatula = auto()
+
+    assert str(Tools) == "Tools(head, horse: float, donkey: int, spatula)"

--- a/test.py
+++ b/test.py
@@ -392,3 +392,49 @@ def test_str_typed():
         spatula = auto()
 
     assert str(Tools) == "Tools(head, horse: float, donkey: int, spatula)"
+
+
+def test_repr_sparse():
+    """Make sure that SparseEnumapMeta's __repr___ method works"""
+    a = SparseEnumap("a", "b c d")
+    assert repr(a) == """a(
+    b,
+    c,
+    d
+)"""
+
+
+def test_repr_sparse_typed():
+    """Make sure that SparseEnumapMeta's __repr___ method works
+    with typed fields
+    """
+    class Tools(SparseEnumap):
+        head = default("your head")
+        horse: float = default(3.14)
+        donkey: int = auto()
+        spatula = 100  # this isn't a default
+
+    # None defaults are not explicitly shown for readability
+    assert repr(Tools) == """Tools(
+    head = 'your head',
+    horse: float = 3.14,
+    donkey: int,
+    spatula
+)"""
+
+
+def test_str_sparse():
+    """Check that SparseEnumapMeta's __str__ method works"""
+    a = SparseEnumap("a", "b c d")
+    assert str(a) == "a(b, c, d)"
+
+
+def test_str_sparse_typed():
+    """Make sure that EnumapMeta's __str___ method works with typed fields"""
+    class Tools(SparseEnumap):
+        head = default("your head")
+        horse: float = default(3.14)
+        donkey: int = auto()
+        spatula = default(1)
+
+    assert str(Tools) == "Tools(head = 'your head', horse: float = 3.14, donkey: int, spatula = 1)"  # noqa


### PR DESCRIPTION
# More informative `__repr__`, `__str__`
This is best demonstrated with this iPython session screenshot:
![image](https://user-images.githubusercontent.com/6044830/32997821-ceb343e4-cd49-11e7-9e0a-cdb1f5b97959.png)

# How it works
The stdlib `enum.Enum` uses `enum.EnumMeta` to provide `__repr__` and `__str__` to subclasses of `enum.Enum`. To get new `__repr__`/`__str__` behavior, `Enumap` and `SparseEnumap` use special `EnumMeta` subclasses as metaclasses. From the `enum` docs:

> The EnumMeta metaclass is responsible for providing the __contains__(), __dir__(), __iter__() and other methods that allow one to do things with an Enum class that fail on a typical class, such as list(Color) or some_var in Color. EnumMeta is responsible for ensuring that various other methods on the final Enum class are correct (such as __new__(), __getnewargs__(), __str__() and __repr__()).

# How this was tested
Eight new unit tests that give `EnumapMeta` and `SparseEnumapMeta` a workout. The stdlib
